### PR TITLE
feat(nh-ai-benchmark): persistent storage for results and prompt workspace [INFRA-82]

### DIFF
--- a/charts/nh-ai-benchmark/Chart.yaml
+++ b/charts/nh-ai-benchmark/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nh-ai-benchmark/templates/deployment-api.yaml
+++ b/charts/nh-ai-benchmark/templates/deployment-api.yaml
@@ -56,9 +56,19 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.volumeMounts }}
+          {{- $persistenceMounts := false }}
+          {{- range $name, $cfg := .Values.persistence }}{{- if $cfg.enabled }}{{- $persistenceMounts = true }}{{- end }}{{- end }}
+          {{- if or .Values.volumeMounts $persistenceMounts }}
           volumeMounts:
+            {{- range $name, $cfg := .Values.persistence }}
+            {{- if $cfg.enabled }}
+            - name: {{ $name }}
+              mountPath: {{ $cfg.mountPath | quote }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           env:
             - name: OI_BASE_URL
@@ -81,8 +91,7 @@ spec:
               value: {{ .Values.env.BEDROCK_EMBEDDINGS_MODEL | quote }}
             - name: CLAUDE_MODEL_ID
               value: {{ .Values.env.CLAUDE_MODEL_ID | quote }}
-            - name: OPEN_WEBUI_UID
-              value: {{ .Values.env.OPEN_WEBUI_UID | quote }}
+
             {{- if .Values.extraEnvVars }}
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}
@@ -93,9 +102,20 @@ spec:
                 name: {{ . }}
             {{- end }}
           {{- end }}
-      {{- with .Values.volumes }}
+      {{- $persistenceVolumes := false }}
+      {{- range $name, $cfg := .Values.persistence }}{{- if $cfg.enabled }}{{- $persistenceVolumes = true }}{{- end }}{{- end }}
+      {{- if or .Values.volumes $persistenceVolumes }}
       volumes:
+        {{- range $name, $cfg := .Values.persistence }}
+        {{- if $cfg.enabled }}
+        - name: {{ $name }}
+          persistentVolumeClaim:
+            claimName: {{ $cfg.existingClaim | default (printf "%s-%s" (include "nh-ai-benchmark.fullname" $) $name) }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/nh-ai-benchmark/templates/pvc.yaml
+++ b/charts/nh-ai-benchmark/templates/pvc.yaml
@@ -1,0 +1,32 @@
+{{- range $name, $cfg := .Values.persistence }}
+{{- if and $cfg.enabled (not $cfg.existingClaim) }}
+{{- $keep := dict }}
+{{- if $cfg.retainOnUninstall }}{{- $keep = dict "helm.sh/resource-policy" "keep" }}{{- end }}
+{{- /* explicit annotations take precedence over the retainOnUninstall toggle on collision */}}
+{{- $annotations := merge (dict) ($cfg.annotations | default dict) $keep }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "nh-ai-benchmark.fullname" $ }}-{{ $name }}
+  labels:
+    {{- include "nh-ai-benchmark.labels" $ | nindent 4 }}
+  {{- with $annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ $cfg.accessMode | default "ReadWriteOnce" | quote }}
+  resources:
+    requests:
+      storage: {{ required (printf "persistence.%s.size is required" $name) $cfg.size | quote }}
+  {{- if $cfg.storageClass }}
+  {{- if (eq "-" $cfg.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ $cfg.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/nh-ai-benchmark/values.yaml
+++ b/charts/nh-ai-benchmark/values.yaml
@@ -139,9 +139,11 @@ persistence:
   results:
     enabled: true
     mountPath: /app/results
-    # -- PVC size — tune per deployment based on expected run-artifact volume.
-    # gp3 supports online expansion (allowVolumeExpansion: true), so this can be raised later.
-    size: 20Gi
+    # -- PVC size (GiB). Default 1Gi, which is also the EBS minimum. gp3 supports online
+    # expansion (allowVolumeExpansion: true), so you can INCREASE this any time (edit + helm
+    # upgrade, no downtime). You CANNOT decrease it — shrinking requires a new PVC + data copy.
+    # So start small and grow as needed.
+    size: 1Gi
     accessMode: ReadWriteOnce
     # -- StorageClass. "" = cluster default (gp3). "-" = disable dynamic provisioning.
     storageClass: ""
@@ -160,7 +162,8 @@ persistence:
   workspace:
     enabled: true
     mountPath: /app/prompts/workspace
-    size: 5Gi
+    # -- PVC size (GiB). Can be increased any time (online expansion); cannot be decreased.
+    size: 1Gi
     accessMode: ReadWriteOnce
     storageClass: ""
     existingClaim: ""

--- a/charts/nh-ai-benchmark/values.yaml
+++ b/charts/nh-ai-benchmark/values.yaml
@@ -126,14 +126,55 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-# Additional volumes on the output Deployment definition.
+# -- Persistent storage for the API container (default gp3 StorageClass, dynamically
+# provisioned by the EBS CSI driver). Sizes are configurable per-deployment — override
+# `size` in values-<env>.yaml. Mount paths match the app's fixed dirs in config.py
+# (BENCH_DIR = /app), so do not change them unless the app layout changes.
+#
+# NOTE: EBS volumes are ReadWriteOnce (single node). The API runs replicaCount: 1, so this
+# is fine. If you ever enable the HPA or scale the API > 1, multiple pods cannot share an
+# RWO EBS volume — you'd need a shared filesystem (e.g. the JuiceFS S3 gateway) instead.
+persistence:
+  # Run artifacts written to /app/results (results/<run_id>/). Persist across restarts.
+  results:
+    enabled: true
+    mountPath: /app/results
+    # -- PVC size — tune per deployment based on expected run-artifact volume.
+    # gp3 supports online expansion (allowVolumeExpansion: true), so this can be raised later.
+    size: 20Gi
+    accessMode: ReadWriteOnce
+    # -- StorageClass. "" = cluster default (gp3). "-" = disable dynamic provisioning.
+    storageClass: ""
+    # -- Use an existing PVC instead of creating one (set to a claim name to bind it).
+    existingClaim: ""
+    annotations: {}
+    # -- When true (default), adds the `helm.sh/resource-policy: keep` annotation so the PVC
+    # (and, with gp3 reclaimPolicy: Delete, its EBS volume + data) survives `helm uninstall`.
+    # Reinstalls with the same release name/namespace reattach the existing data automatically.
+    # Set false to have the PVC removed on uninstall (which destroys the EBS volume + data).
+    # Retained PVCs are not freed automatically — delete manually (kubectl delete pvc) when no
+    # longer needed, as they keep incurring cost. Merges with `annotations`; explicit wins.
+    retainOnUninstall: true
+  # Per-user editable prompt suites at /app/prompts/workspace (prompts/workspace/<user_id>/).
+  # prompts/official and prompts.json ship in the image and are left untouched.
+  workspace:
+    enabled: true
+    mountPath: /app/prompts/workspace
+    size: 5Gi
+    accessMode: ReadWriteOnce
+    storageClass: ""
+    existingClaim: ""
+    annotations: {}
+    retainOnUninstall: true
+
+# Additional volumes on the output Deployment definition (merged with persistence volumes above).
 volumes: []
 # - name: foo
 #   secret:
 #     secretName: mysecret
 #     optional: false
 
-# Additional volumeMounts on the output Deployment definition.
+# Additional volumeMounts on the output Deployment definition (merged with persistence mounts above).
 volumeMounts: []
 # - name: foo
 #   mountPath: "/etc/foo"
@@ -146,12 +187,11 @@ tolerations: []
 affinity: {}
 
 # -- Environment variables for the API container.
-# Sensitive values (OI_API_KEY, OPEN_WEBUI_UID, AWS_*, QDRANT_API_KEY) should be
+# Sensitive values (OI_API_KEY, AWS_*, QDRANT_API_KEY) should be
 # provided via secretName (envFrom) rather than set here in plain text.
 # Required values are commented out — deployment will fail if not set, which is intentional.
 env:
   # OI_BASE_URL: ""
-  # OPEN_WEBUI_UID: ""
   # RAG_BASE_URL: ""
   # PIPELINES_BASE_URL: ""
   # MCP_BASE_URL: ""


### PR DESCRIPTION
## What
Adds optional PVC-backed persistence to the nh-ai-benchmark API so run artifacts
and per-user prompt workspaces survive pod restarts.

- `persistence` block: results -> /app/results, workspace -> /app/prompts/workspace (both on by default)
- PVCs from the default gp3 StorageClass (RWO); size/storageClass/accessMode overridable per deployment
- Default size 1Gi (EBS minimum); grow-only via online expansion, cannot shrink
- `retainOnUninstall` (default true) adds helm.sh/resource-policy: keep so data survives uninstall and reattaches on reinstall
- `existingClaim` support; mounts wired into the API deployment only (UI stays stateless)

## Notes
- Single-replica/RWO is intentional; scaling >1 needs a shared filesystem (out of scope).
- retainOnUninstall=true leaves orphaned PVCs/EBS on uninstall — clean up manually when no longer needed.

[INFRA-82]


[INFRA-82]: https://nethopper.atlassian.net/browse/INFRA-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ